### PR TITLE
Use python3 in shebang of manage.py

### DIFF
--- a/project/Board/manage.py
+++ b/project/Board/manage.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """Django's command-line utility for administrative tasks."""
 import os
 import sys


### PR DESCRIPTION
This patch replaces python with python3 in shebang of the manage.py file.